### PR TITLE
Rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cvar"
-version = "0.3.1"
-edition = "2018"
+version = "0.4.0"
+edition = "2021"
 authors = ["Casper <CasualX@users.noreply.github.com>"]
 
 description = "Configuration variables."

--- a/examples/readme-example.rs
+++ b/examples/readme-example.rs
@@ -6,6 +6,7 @@ pub struct ProgramState {
 	number: i32,
 	text: String,
 }
+
 impl ProgramState {
 	pub fn poke(&mut self, args: &str) {
 		self.text = format!("{}: {}", args, self.number);
@@ -14,13 +15,15 @@ impl ProgramState {
 
 impl cvar::IVisit for ProgramState {
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn cvar::INode)) {
-		f(&mut cvar::Property("number", &mut self.number, 42));
-		f(&mut cvar::Property("text", &mut self.text, String::new()));
-		f(&mut cvar::Action("poke!", |args, _console| self.poke(args)));
+		f(&mut cvar::Property("number", &mut self.number, &42));
+		f(&mut cvar::Property("text", &mut self.text, &String::new()));
+		f(&mut cvar::Action("poke!", |args, _writer| self.poke(args)));
 	}
 }
 
 fn main() {
+	let mut writer = String::new();
+
 	let mut program_state = ProgramState {
 		number: 42,
 		text: String::new(),
@@ -28,10 +31,9 @@ fn main() {
 
 	assert_eq!(cvar::console::get(&mut program_state, "number").unwrap(), "42");
 
-	cvar::console::set(&mut program_state, "number", "13").unwrap();
+	cvar::console::set(&mut program_state, "number", "13", &mut writer);
 	assert_eq!(program_state.number, 13);
 
-	let mut console = String::new();
-	cvar::console::invoke(&mut program_state, "poke!", "the value is", &mut console);
+	cvar::console::invoke(&mut program_state, "poke!", "the value is", &mut writer);
 	assert_eq!(program_state.text, "the value is: 13");
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ pub struct ProgramState {
 	number: i32,
 	text: String,
 }
+
 impl ProgramState {
 	pub fn poke(&mut self, args: &str) {
 		self.text = format!("{}: {}", args, self.number);
@@ -59,9 +60,9 @@ This is ordinary Rust code, the idea is that you have some long-lived state that
 ```rust
 impl cvar::IVisit for ProgramState {
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn cvar::INode)) {
-		f(&mut cvar::Property("number", &mut self.number, 42));
-		f(&mut cvar::Property("text", &mut self.text, String::new()));
-		f(&mut cvar::Action("poke!", |args, _console| self.poke(args)));
+		f(&mut cvar::Property("number", &mut self.number, &42));
+		f(&mut cvar::Property("text", &mut self.text, &String::new()));
+		f(&mut cvar::Action("poke!", |args, _writer| self.poke(args)));
 	}
 }
 ```
@@ -93,8 +94,8 @@ assert_eq!(program_state.number, 13);
 Get or set properties by their textual names and values through a console like interface.
 
 ```rust
-let mut console = String::new();
-cvar::console::invoke(&mut program_state, "poke!", "the value is", &mut console);
+let mut writer = String::new();
+cvar::console::invoke(&mut program_state, "poke!", "the value is", &mut writer);
 assert_eq!(program_state.text, "the value is: 13");
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,21 +8,22 @@ The following snippet defines our program state with a user name and a method to
 pub struct User {
 	name: String,
 }
+
 impl User {
-	pub fn greet(&self, console: &mut dyn cvar::IConsole) {
-		let _ = writeln!(console, "Hello, {}!", self.name);
+	pub fn greet(&self, writer: &mut dyn cvar::IWrite) {
+		let _ = writeln!(writer, "Hello, {}!", self.name);
 	}
 }
 ```
 
-Implement [the `IVisit` trait](trait.IVisit.html) to make this structure available for interactivity:
+Implement the [`IVisit`] trait to make this structure available for interactivity:
 
 ```
-# struct User { name: String } impl User { pub fn greet(&self, console: &mut dyn cvar::IConsole) { let _ = writeln!(console, "Hello, {}!", self.name); } }
+# struct User { name: String } impl User { pub fn greet(&self, writer: &mut dyn cvar::IWrite) { let _ = writeln!(writer, "Hello, {}!", self.name); } }
 impl cvar::IVisit for User {
-	fn visit(&mut self, f: &mut FnMut(&mut cvar::INode)) {
-		f(&mut cvar::Property("name", &mut self.name, String::new()));
-		f(&mut cvar::Action("greet!", |_args, console| self.greet(console)));
+	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn cvar::INode)) {
+		f(&mut cvar::Property("name", &mut self.name, &String::new()));
+		f(&mut cvar::Action("greet!", |_args, writer| self.greet(writer)));
 	}
 }
 ```
@@ -30,7 +31,7 @@ impl cvar::IVisit for User {
 That's it! Create an instance of the structure to interact with:
 
 ```
-# struct User { name: String } impl User { pub fn greet(&self, console: &mut dyn cvar::IConsole) { let _ = writeln!(console, "Hello, {}!", self.name); } }
+# struct User { name: String } impl User { pub fn greet(&self, writer: &mut dyn cvar::IWrite) { let _ = writeln!(writer, "Hello, {}!", self.name); } }
 let mut user = User {
 	name: String::new(),
 };
@@ -39,17 +40,18 @@ let mut user = User {
 Given unique access, interact with the instance with a stringly typed API:
 
 ```
-# struct User { name: String } impl User { pub fn greet(&self, console: &mut dyn cvar::IConsole) { let _ = writeln!(console, "Hello, {}!", self.name); } }
-# impl cvar::IVisit for User { fn visit(&mut self, f: &mut FnMut(&mut cvar::INode)) { f(&mut cvar::Property("name", &mut self.name, String::new())); f(&mut cvar::Action("greet!", |_args, console| self.greet(console))); } }
+# struct User { name: String } impl User { pub fn greet(&self, writer: &mut dyn cvar::IWrite) { let _ = writeln!(writer, "Hello, {}!", self.name); } }
+# impl cvar::IVisit for User { fn visit(&mut self, f: &mut dyn FnMut(&mut dyn cvar::INode)) { f(&mut cvar::Property("name", &mut self.name, &String::new())); f(&mut cvar::Action("greet!", |_args, writer| self.greet(writer))); } }
 # let mut user = User { name: String::new() };
+let mut writer = String::new();
+
 // Give the user a name
-cvar::console::set(&mut user, "name", "World").unwrap();
+cvar::console::set(&mut user, "name", "World", &mut writer);
 assert_eq!(user.name, "World");
 
-// Greet the user, the message is printed to the console string
-let mut console = String::new();
-cvar::console::invoke(&mut user, "greet!", "", &mut console);
-assert_eq!(console, "Hello, World!\n");
+// Greet the user, the message is printed to the writer
+cvar::console::invoke(&mut user, "greet!", "", &mut writer);
+assert_eq!(writer, "Hello, World!\n");
 ```
 
 This example is extremely basic, for more complex scenarios see the examples.
@@ -62,17 +64,16 @@ pub mod console;
 #[cfg(test)]
 mod tests;
 
-/// Result with boxed error.
-type BoxResult<T> = Result<T, Box<dyn StdError + Send + Sync + 'static>>;
-
 //----------------------------------------------------------------
 
 /// Node interface.
 pub trait INode {
 	/// Returns the node name.
 	fn name(&self) -> &str;
+
 	/// Downcasts to a more specific node interface.
 	fn as_node(&mut self) -> Node<'_>;
+
 	/// Upcasts back to an `INode` trait object.
 	fn as_inode(&mut self) -> &mut dyn INode;
 }
@@ -84,6 +85,7 @@ pub enum Node<'a> {
 	List(&'a mut dyn IList),
 	Action(&'a mut dyn IAction),
 }
+
 impl INode for Node<'_> {
 	fn name(&self) -> &str {
 		match self {
@@ -92,6 +94,7 @@ impl INode for Node<'_> {
 			Node::Action(act) => act.name(),
 		}
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		match self {
 			Node::Prop(prop) => Node::Prop(*prop),
@@ -99,7 +102,55 @@ impl INode for Node<'_> {
 			Node::Action(act) => Node::Action(*act),
 		}
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
+		self
+	}
+}
+
+//----------------------------------------------------------------
+
+/// Property values.
+pub trait IValue: any::Any + fmt::Display {
+	/// Returns the value as a `&dyn Any` trait object.
+	fn as_any(&self) -> &dyn any::Any;
+
+	/// Returns the name of the concrete type.
+	#[cfg(feature = "type_name")]
+	fn type_name(&self) -> &str {
+		any::type_name::<Self>()
+	}
+}
+impl fmt::Debug for dyn IValue {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		fmt::Display::fmt(self, f)
+	}
+}
+
+impl dyn IValue {
+	/// Returns `true` if the inner type is the same as `T`.
+	#[inline]
+	pub fn is<T: any::Any>(&self) -> bool {
+		any::TypeId::of::<T>() == self.type_id()
+	}
+
+	/// Returns some reference to the inner value if it is of type `T`, or `None` if it isn't.
+	#[inline]
+	pub fn downcast_ref<T: any::Any>(&self) -> Option<&T> {
+		if self.is::<T>() {
+			Some(unsafe { &*(self as *const dyn IValue as *const T) })
+		}
+		else {
+			None
+		}
+	}
+}
+
+impl<T: 'static + Sized> IValue for T
+	where T: Clone + Default + PartialEq + fmt::Display + FromStr,
+	      T::Err: StdError + Send + Sync + 'static
+{
+	fn as_any(&self) -> &dyn any::Any {
 		self
 	}
 }
@@ -108,6 +159,7 @@ impl INode for Node<'_> {
 
 /// Property state.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum PropState {
 	/// The property has its default value set.
 	Default,
@@ -121,29 +173,39 @@ pub enum PropState {
 ///
 /// Provides an object safe interface for properties, type erasing its implementation.
 pub trait IProperty: INode {
-	/// Gets the value as a string.
-	fn get(&self) -> String;
+	/// Gets the value.
+	fn get_value(&self) -> &dyn IValue;
+
 	/// Sets the value.
-	fn set(&mut self, val: &str) -> BoxResult<()>;
+	fn set_value(&mut self, val: &dyn IValue, writer: &mut dyn IWrite) -> bool;
+
+	/// Sets the value parsed from string.
+	fn set(&mut self, val: &str, writer: &mut dyn IWrite) -> bool;
+
 	/// Resets the value to its default.
 	///
 	/// If this operation fails (for eg. read-only properties), it does so silently.
 	fn reset(&mut self);
-	/// Gets the default value as a string.
-	fn default(&self) -> String;
+
+	/// Gets the default value.
+	fn default_value(&self) -> &dyn IValue;
+
 	/// Returns the state of the property.
 	fn state(&self) -> PropState;
+
 	/// Returns the flags associated with the property.
 	///
 	/// The meaning of this value is defined by the caller.
 	fn flags(&self) -> u32 {
 		0
 	}
-	/// Returns the name of this concrete type.
+
+	/// Returns the name of the concrete type.
 	#[cfg(feature = "type_name")]
 	fn type_name(&self) -> &str {
 		any::type_name::<Self>()
 	}
+
 	/// Returns a list of valid value strings for this property.
 	///
 	/// None if the question is not relevant, eg. string or number nodes.
@@ -151,71 +213,103 @@ pub trait IProperty: INode {
 		None
 	}
 }
+
 impl fmt::Debug for dyn IProperty + '_ {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		let mut debug = f.debug_struct("IProperty");
 		debug.field("name", &self.name());
-		debug.field("value", &self.get());
-		debug.field("default", &self.default());
+		debug.field("value", &self.get_value());
+		debug.field("default", &self.default_value());
 		debug.field("state", &self.state());
 		debug.field("flags", &self.flags());
 		#[cfg(feature = "type_name")]
 		debug.field("type", &self.type_name());
 		debug.field("values", &self.values());
-		debug.finish()
+		debug.finish_non_exhaustive()
 	}
 }
 
 //----------------------------------------------------------------
 
 /// Property node.
-pub struct Property<'a, T> {
+pub struct Property<'a, 'x, T: 'static> {
 	name: &'a str,
-	variable: &'a mut T,
-	default: T,
+	variable: &'x mut T,
+	default: &'a T,
 }
+
 #[allow(non_snake_case)]
-pub fn Property<'a, T>(name: &'a str, variable: &'a mut T, default: T) -> Property<'a, T> {
+#[inline]
+pub fn Property<'a, 'x, T>(name: &'a str, variable: &'x mut T, default: &'a T) -> Property<'a, 'x, T> {
 	Property { name, variable, default }
 }
-impl<'a, T> Property<'a, T> {
-	pub fn new(name: &'a str, variable: &'a mut T, default: T) -> Property<'a, T> {
+
+impl<'a, 'x, T> Property<'a, 'x, T> {
+	#[inline]
+	pub fn new(name: &'a str, variable: &'x mut T, default: &'a T) -> Property<'a, 'x, T> {
 		Property { name, variable, default }
 	}
 }
-impl<'a, T> INode for Property<'a, T>
-	where T: FromStr + ToString + Clone + PartialEq,
+
+impl<'a, 'x, T> INode for Property<'a, 'x, T>
+	where T: Clone + Default + PartialEq + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
 	fn name(&self) -> &str {
 		self.name
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		Node::Prop(self)
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
 		self
 	}
 }
-impl<'a, T> IProperty for Property<'a, T>
-	where T: FromStr + ToString + Clone + PartialEq,
+
+impl<'a, 'x, T> IProperty for Property<'a, 'x, T>
+	where T: Clone + Default + PartialEq + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
-	fn get(&self) -> String {
-		self.variable.to_string()
+	fn get_value(&self) -> &dyn IValue {
+		&*self.variable
 	}
-	fn set(&mut self, val: &str) -> BoxResult<()> {
-		*self.variable = T::from_str(val)?;
-		Ok(())
+
+	fn set_value(&mut self, val: &dyn IValue, writer: &mut dyn IWrite) -> bool {
+		if let Some(val) = val.downcast_ref::<T>() {
+			self.variable.clone_from(val);
+			true
+		}
+		else {
+			let _ = write_mismatched_types::<T>(writer, val);
+			false
+		}
 	}
+
+	fn set(&mut self, val: &str, writer: &mut dyn IWrite) -> bool {
+		match val.parse::<T>() {
+			Ok(val) => {
+				*self.variable = val;
+				true
+			},
+			Err(err) => {
+				let _ = write_error(writer, &err);
+				false
+			},
+		}
+	}
+
 	fn reset(&mut self) {
 		self.variable.clone_from(&self.default);
 	}
-	fn default(&self) -> String {
-		self.default.to_string()
+
+	fn default_value(&self) -> &dyn IValue {
+		&*self.default
 	}
+
 	fn state(&self) -> PropState {
-		match *self.variable == self.default {
+		match *self.variable == *self.default {
 			true => PropState::Default,
 			false => PropState::UserSet,
 		}
@@ -224,62 +318,108 @@ impl<'a, T> IProperty for Property<'a, T>
 
 //----------------------------------------------------------------
 
-/// Property node with its value clamped.
-pub struct ClampedProp<'a, T> {
-	name: &'a str,
-	variable: &'a mut T,
-	default: T,
-	min: T,
-	max: T,
+#[inline]
+fn check_bounds_inclusive<T: PartialOrd>(val: &T, min: Option<&T>, max: Option<&T>) -> bool {
+	if let Some(min) = min {
+		if *val >= *min {
+			return true;
+		}
+		return false;
+	}
+	if let Some(max) = max {
+		if *val <= *max {
+			return true;
+		}
+		return false;
+	}
+	return true;
 }
+
+/// Property node with its value clamped.
+pub struct ClampedProp<'a, 'x, T: 'static> {
+	name: &'a str,
+	variable: &'x mut T,
+	default: &'a T,
+	min: Option<&'a T>,
+	max: Option<&'a T>,
+}
+
 #[allow(non_snake_case)]
-pub fn ClampedProp<'a, T>(name: &'a str, variable: &'a mut T, default: T, min: T, max: T) -> ClampedProp<'a, T> {
+#[inline]
+pub fn ClampedProp<'a, 'x, T>(name: &'a str, variable: &'x mut T, default: &'a T, min: Option<&'a T>, max: Option<&'a T>) -> ClampedProp<'a, 'x, T> {
 	ClampedProp { name, variable, default, min, max }
 }
-impl<'a, T> ClampedProp<'a, T> {
-	pub fn new(name: &'a str, variable: &'a mut T, default: T, min: T, max: T) -> ClampedProp<'a, T> {
+
+impl<'a, 'x, T> ClampedProp<'a, 'x, T> {
+	#[inline]
+	pub fn new(name: &'a str, variable: &'x mut T, default: &'a T, min: Option<&'a T>, max: Option<&'a T>) -> ClampedProp<'a, 'x, T> {
 		ClampedProp { name, variable, default, min, max }
 	}
 }
-impl<'a, T> INode for ClampedProp<'a, T>
-	where T: FromStr + ToString + Clone + PartialEq + PartialOrd,
+
+impl<'a, 'x, T> INode for ClampedProp<'a, 'x, T>
+	where T: Clone + Default + PartialEq + PartialOrd + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
 	fn name(&self) -> &str {
 		self.name
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		Node::Prop(self)
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
 		self
 	}
 }
-impl<'a, T> IProperty for ClampedProp<'a, T>
-	where T: FromStr + ToString + Clone + PartialEq + PartialOrd,
+
+impl<'a, 'x, T> IProperty for ClampedProp<'a, 'x, T>
+	where T: Clone + Default + PartialEq + PartialOrd + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
-	fn get(&self) -> String {
-		self.variable.to_string()
+	fn get_value(&self) -> &dyn IValue {
+		&*self.variable
 	}
-	fn set(&mut self, val: &str) -> BoxResult<()> {
-		*self.variable = T::from_str(val)?;
-		if *self.variable < self.min {
-			self.variable.clone_from(&self.min);
+
+	fn set_value(&mut self, val: &dyn IValue, writer: &mut dyn IWrite) -> bool {
+		if let Some(val) = val.downcast_ref::<T>() {
+			if check_bounds_inclusive(val, self.min, self.max) {
+				self.variable.clone_from(val);
+			}
+			true
 		}
-		if *self.variable > self.max {
-			self.variable.clone_from(&self.max);
+		else {
+			let _ = write_mismatched_types::<T>(writer, val);
+			false
 		}
-		Ok(())
 	}
+
+	fn set(&mut self, val: &str, writer: &mut dyn IWrite) -> bool {
+		match val.parse::<T>() {
+			Ok(val) => {
+				if check_bounds_inclusive(&val, self.min, self.max) {
+					*self.variable = val;
+				}
+				true
+			},
+			Err(err) => {
+				let _ = write_error(writer, &err);
+				false
+			},
+		}
+	}
+
 	fn reset(&mut self) {
 		self.variable.clone_from(&self.default);
 	}
-	fn default(&self) -> String {
-		self.default.to_string()
+
+	fn default_value(&self) -> &dyn IValue {
+		&*self.default
 	}
+
 	fn state(&self) -> PropState {
-		match *self.variable == self.default {
+		match *self.variable == *self.default {
 			true => PropState::Default,
 			false => PropState::UserSet,
 		}
@@ -289,44 +429,62 @@ impl<'a, T> IProperty for ClampedProp<'a, T>
 //----------------------------------------------------------------
 
 /// Read-only property node.
-pub struct ReadOnlyProp<'a, T> {
+pub struct ReadOnlyProp<'a, T: 'static> {
 	name: &'a str,
 	variable: &'a T,
-	default: T,
+	default: &'a T,
 }
+
 #[allow(non_snake_case)]
-pub fn ReadOnlyProp<'a, T>(name: &'a str, variable: &'a T, default: T) -> ReadOnlyProp<'a, T> {
+#[inline]
+pub fn ReadOnlyProp<'a, T>(name: &'a str, variable: &'a T, default: &'a T) -> ReadOnlyProp<'a, T> {
 	ReadOnlyProp { name, variable, default }
 }
+
 impl<'a, T> ReadOnlyProp<'a, T> {
-	pub fn new(name: &'a str, variable: &'a T, default: T) -> ReadOnlyProp<'a, T> {
+	#[inline]
+	pub fn new(name: &'a str, variable: &'a T, default: &'a T) -> ReadOnlyProp<'a, T> {
 		ReadOnlyProp { name, variable, default }
 	}
 }
-impl<'a, T: ToString + PartialEq> INode for ReadOnlyProp<'a, T> {
+
+impl<'a, T: PartialEq + IValue> INode for ReadOnlyProp<'a, T> {
 	fn name(&self) -> &str {
 		self.name
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		Node::Prop(self)
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
 		self
 	}
 }
-impl<'a, T: ToString + PartialEq> IProperty for ReadOnlyProp<'a, T> {
-	fn get(&self) -> String {
-		self.variable.to_string()
+
+impl<'a, T: PartialEq + IValue> IProperty for ReadOnlyProp<'a, T> {
+	fn get_value(&self) -> &dyn IValue {
+		&*self.variable
 	}
-	fn set(&mut self, _val: &str) -> BoxResult<()> {
-		Err("cannot set read-only property".into())
+
+	fn set_value(&mut self, _val: &dyn IValue, writer: &mut dyn IWrite) -> bool {
+		let _ = writer.write_str("cannot set read-only property");
+		false
 	}
+
+	fn set(&mut self, _val: &str, writer: &mut dyn IWrite) -> bool {
+		let _ = writer.write_str("cannot set read-only property");
+		false
+	}
+
 	fn reset(&mut self) {}
-	fn default(&self) -> String {
-		self.default.to_string()
+
+	fn default_value(&self) -> &dyn IValue {
+		&*self.default
 	}
+
 	fn state(&self) -> PropState {
-		match *self.variable == self.default {
+		match *self.variable == *self.default {
 			true => PropState::Default,
 			false => PropState::UserSet,
 		}
@@ -336,46 +494,83 @@ impl<'a, T: ToString + PartialEq> IProperty for ReadOnlyProp<'a, T> {
 //----------------------------------------------------------------
 
 /// Property node which owns its variable.
-pub struct OwnedProp<T> {
+pub struct OwnedProp<T: 'static> {
 	pub name: String,
 	pub variable: T,
 	pub default: T,
 	_private: (),
 }
+
 #[allow(non_snake_case)]
+#[inline]
 pub fn OwnedProp<T>(name: String, variable: T, default: T) -> OwnedProp<T> {
 	OwnedProp { name, variable, default, _private: () }
 }
+
 impl<T> OwnedProp<T> {
+	#[inline]
 	pub fn new(name: String, variable: T, default: T) -> OwnedProp<T> {
 		OwnedProp { name, variable, default, _private: () }
 	}
 }
+
 impl<T> INode for OwnedProp<T>
-	where T: FromStr + ToString + Clone + PartialEq,
+	where T: Clone + Default + PartialEq + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
-	fn name(&self) -> &str { &self.name }
-	fn as_node(&mut self) -> Node<'_> { Node::Prop(self) }
-	fn as_inode(&mut self) -> &mut dyn INode { self }
+	fn name(&self) -> &str {
+		&self.name
+	}
+
+	fn as_node(&mut self) -> Node<'_> {
+		Node::Prop(self)
+	}
+
+	fn as_inode(&mut self) -> &mut dyn INode {
+		self
+	}
 }
+
 impl<T> IProperty for OwnedProp<T>
-	where T: FromStr + ToString + Clone + PartialEq,
+	where T: Clone + Default + PartialEq + fmt::Display + FromStr,
 	      T::Err: StdError + Send + Sync + 'static
 {
-	fn get(&self) -> String {
-		self.variable.to_string()
+	fn get_value(&self) -> &dyn IValue {
+		&self.variable
 	}
-	fn set(&mut self, val: &str) -> BoxResult<()> {
-		self.variable = T::from_str(val)?;
-		Ok(())
+
+	fn set_value(&mut self, val: &dyn IValue, writer: &mut dyn IWrite) -> bool {
+		if let Some(val) = val.downcast_ref::<T>() {
+			self.variable.clone_from(val);
+			true
+		}
+		else {
+			let _ = write_mismatched_types::<T>(writer, val);
+			false
+		}
 	}
+
+	fn set(&mut self, val: &str, writer: &mut dyn IWrite) -> bool {
+		match val.parse::<T>() {
+			Ok(val) => {
+				self.variable = val;
+				true
+			},
+			Err(err) => {
+				let _ = write_error(writer, &err);
+				false
+			},
+		}
+	}
+
 	fn reset(&mut self) {
 		self.variable.clone_from(&self.default);
 	}
-	fn default(&self) -> String {
-		self.default.to_string()
+
+	fn default_value(&self) -> &dyn IValue {
+		&self.default
 	}
+
 	fn state(&self) -> PropState {
 		match self.variable == self.default {
 			true => PropState::Default,
@@ -396,10 +591,11 @@ impl<T> IProperty for OwnedProp<T>
 /// struct Foo {
 /// 	data: i32,
 /// }
+///
 /// impl cvar::IVisit for Foo {
-/// 	fn visit(&mut self, f: &mut FnMut(&mut cvar::INode)) {
+/// 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn cvar::INode)) {
 /// 		// Pass type-erased properties, lists and actions to the closure
-/// 		f(&mut cvar::Property("data", &mut self.data, 42));
+/// 		f(&mut cvar::Property("data", &mut self.data, &42));
 /// 	}
 /// }
 /// ```
@@ -409,30 +605,33 @@ pub trait IVisit {
 	/// Callers may depend on the particular order in which the nodes are passed to the closure.
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn INode));
 }
+
 impl fmt::Debug for dyn IVisit + '_ {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		// Cannot visit the children as we do not have unique access to self...
-		f.write_str("IVisit { .. }")
+		f.debug_struct("IVisit").finish_non_exhaustive()
 	}
 }
 
 /// Node visitor from closure.
 ///
-/// The visitor trait `IVisit` requires a struct type to be implemented.
+/// The visitor trait [`IVisit`] requires a struct type to be implemented.
 /// This wrapper type allows a visitor to be created out of a closure instead.
 ///
 /// ```
 /// let mut value = 0;
 ///
 /// let mut visitor = cvar::Visit(|f| {
-/// 	f(&mut cvar::Property("value", &mut value, 0));
+/// 	f(&mut cvar::Property("value", &mut value, &0));
 /// });
 ///
-/// let _ = cvar::console::set(&mut visitor, "value", "42");
+/// let mut writer = String::new();
+/// let _ = cvar::console::set(&mut visitor, "value", "42", &mut writer);
 /// assert_eq!(value, 42);
 /// ```
 #[derive(Copy, Clone, Debug)]
 pub struct Visit<F: FnMut(&mut dyn FnMut(&mut dyn INode))>(pub F);
+
 impl<F: FnMut(&mut dyn FnMut(&mut dyn INode))> IVisit for Visit<F> {
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn INode)) {
 		let Self(this) = self;
@@ -444,16 +643,17 @@ impl<F: FnMut(&mut dyn FnMut(&mut dyn INode))> IVisit for Visit<F> {
 
 /// List of child nodes.
 ///
-/// You probably want to implement [the `IVisit` trait](trait.IVisit.html) instead of this one.
+/// You probably want to implement the [`IVisit`] trait instead of this one.
 pub trait IList: INode {
 	/// Returns a visitor trait object to visit the children.
 	fn as_ivisit(&mut self) -> &mut dyn IVisit;
 }
+
 impl fmt::Debug for dyn IList + '_ {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("IList")
 			.field("name", &self.name())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
@@ -461,31 +661,39 @@ impl fmt::Debug for dyn IList + '_ {
 
 /// List node.
 #[derive(Debug)]
-pub struct List<'a> {
+pub struct List<'a, 'x> {
 	name: &'a str,
-	visitor: &'a mut dyn IVisit,
+	visitor: &'x mut dyn IVisit,
 }
+
 #[allow(non_snake_case)]
-pub fn List<'a>(name: &'a str, visitor: &'a mut dyn IVisit) -> List<'a> {
+#[inline]
+pub fn List<'a, 'x>(name: &'a str, visitor: &'x mut dyn IVisit) -> List<'a, 'x> {
 	List { name, visitor }
 }
-impl<'a> List<'a> {
-	pub fn new(name: &'a str, visitor: &'a mut dyn IVisit) -> List<'a> {
+
+impl<'a, 'x> List<'a, 'x> {
+	#[inline]
+	pub fn new(name: &'a str, visitor: &'x mut dyn IVisit) -> List<'a, 'x> {
 		List { name, visitor }
 	}
 }
-impl<'a> INode for List<'a> {
+
+impl<'a, 'x> INode for List<'a, 'x> {
 	fn name(&self) -> &str {
 		self.name
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		Node::List(self)
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
 		self
 	}
 }
-impl<'a> IList for List<'a> {
+
+impl<'a, 'x> IList for List<'a, 'x> {
 	fn as_ivisit(&mut self) -> &mut dyn IVisit {
 		self.visitor
 	}
@@ -493,36 +701,77 @@ impl<'a> IList for List<'a> {
 
 //----------------------------------------------------------------
 
-/// Console interface for actions to write output to.
-pub trait IConsole: any::Any + fmt::Write {
-	/// Notifies the console an error has occurred.
-	fn write_error(&mut self, err: &(dyn StdError + 'static));
-}
+/// Console interface for actions to writer output to.
+pub trait IWrite: any::Any + fmt::Write {}
 
-impl IConsole for String {
-	fn write_error(&mut self, err: &(dyn StdError + 'static)) {
-		let _ = writeln!(self as &mut dyn fmt::Write, "error: {}", err);
+impl dyn IWrite {
+	/// Returns `true` if the inner type is the same as `T`.
+	#[inline]
+	pub fn is<T: any::Any>(&self) -> bool {
+		any::TypeId::of::<T>() == self.type_id()
+	}
+
+	/// Returns some reference to the inner value if it is of type `T`, or `None` if it isn't.
+	#[inline]
+	pub fn downcast_ref<T: any::Any>(&self) -> Option<&T> {
+		if self.is::<T>() {
+			Some(unsafe { &*(self as *const dyn IWrite as *const T) })
+		}
+		else {
+			None
+		}
+	}
+
+	/// Returns some mutable reference to the inner value if it is of type `T`, or `None` if it isn't.
+	#[inline]
+	pub fn downcast_mut<T: any::Any>(&mut self) -> Option<&mut T> {
+		if self.is::<T>() {
+			Some(unsafe { &mut *(self as *mut dyn IWrite as *mut T) })
+		}
+		else {
+			None
+		}
 	}
 }
 
-/// Null console for actions.
+#[inline]
+fn write_error<T: ?Sized + StdError>(writer: &mut dyn IWrite, v: &T) -> fmt::Result {
+	writer.write_fmt(format_args!("{}", v))
+}
+
+#[cfg(feature = "type_name")]
+#[inline]
+fn write_mismatched_types<T: IValue>(writer: &mut dyn IWrite, val: &dyn IValue) -> fmt::Result {
+	write!(writer, "mismatched types: expected `{}`, found `{}`", any::type_name::<T>(), val.type_name())
+}
+
+#[cfg(not(feature = "type_name"))]
+#[inline]
+fn write_mismatched_types<T: IValue>(writer: &mut dyn IWrite, _val: &dyn IValue) -> fmt::Result {
+	writer.write_str("mismatched types")
+}
+
+impl IWrite for String {}
+
+/// Null writer.
 ///
 /// Helper which acts as `dev/null`, any writes disappear in the void.
-pub struct NullConsole;
-impl fmt::Write for NullConsole {
+pub struct NullWriter;
+
+impl fmt::Write for NullWriter {
 	fn write_str(&mut self, _s: &str) -> fmt::Result { Ok(()) }
 	fn write_char(&mut self, _c: char) -> fmt::Result { Ok(()) }
 	fn write_fmt(&mut self, _args: fmt::Arguments) -> fmt::Result { Ok(()) }
 }
-impl IConsole for NullConsole {
-	fn write_error(&mut self, _err: &(dyn StdError + 'static)) {}
-}
 
-/// Io console for actions.
+impl IWrite for NullWriter {}
+
+/// Io writer.
 ///
-/// Helper which adapts a console to write to any `std::io::Write` objects such as stdout.
-pub struct IoConsole<W>(pub W);
-impl<W: io::Write> fmt::Write for IoConsole<W> {
+/// Helper which adapts to any `std::io::Write` objects such as stdout.
+pub struct IoWriter<W>(pub W);
+
+impl<W: io::Write> fmt::Write for IoWriter<W> {
 	fn write_str(&mut self, s: &str) -> fmt::Result {
 		let Self(this) = self;
 		io::Write::write_all(this, s.as_bytes()).map_err(|_| fmt::Error)
@@ -532,20 +781,20 @@ impl<W: io::Write> fmt::Write for IoConsole<W> {
 		io::Write::write_fmt(this, args).map_err(|_| fmt::Error)
 	}
 }
-impl<W: io::Write + 'static> IConsole for IoConsole<W> {
-	fn write_error(&mut self, err: &(dyn StdError + 'static)) {
-		let Self(this) = self;
-		let _ = writeln!(this, "error: {}", err);
+
+impl<W: io::Write + 'static> IWrite for IoWriter<W> {}
+
+impl IoWriter<io::Stdout> {
+	#[inline]
+	pub fn stdout() -> IoWriter<io::Stdout> {
+		IoWriter(io::stdout())
 	}
 }
-impl IoConsole<io::Stdout> {
-	pub fn stdout() -> IoConsole<io::Stdout> {
-		IoConsole(io::stdout())
-	}
-}
-impl IoConsole<io::Stderr> {
-	pub fn stderr() -> IoConsole<io::Stderr> {
-		IoConsole(io::stderr())
+
+impl IoWriter<io::Stderr> {
+	#[inline]
+	pub fn stderr() -> IoWriter<io::Stderr> {
+		IoWriter(io::stderr())
 	}
 }
 
@@ -557,14 +806,15 @@ impl IoConsole<io::Stderr> {
 pub trait IAction: INode {
 	/// Invokes the closure associated with the Action.
 	///
-	/// Given argument string and a console interface to write output to.
-	fn invoke(&mut self, args: &str, console: &mut dyn IConsole);
+	/// Given argument string and a console interface to writer output to.
+	fn invoke(&mut self, args: &str, writer: &mut dyn IWrite);
 }
+
 impl fmt::Debug for dyn IAction + '_ {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_struct("IAction")
 			.field("name", &self.name())
-			.finish()
+			.finish_non_exhaustive()
 	}
 }
 
@@ -572,32 +822,40 @@ impl fmt::Debug for dyn IAction + '_ {
 
 /// Action node.
 #[derive(Debug)]
-pub struct Action<'a, F: FnMut(&str, &mut dyn IConsole)> {
+pub struct Action<'a, F: FnMut(&str, &mut dyn IWrite)> {
 	name: &'a str,
 	invoke: F,
 }
+
 #[allow(non_snake_case)]
-pub fn Action<'a, F: FnMut(&str, &mut dyn IConsole)>(name: &'a str, invoke: F) -> Action<'a, F> {
+#[inline]
+pub fn Action<'a, F: FnMut(&str, &mut dyn IWrite)>(name: &'a str, invoke: F) -> Action<'a, F> {
 	Action { name, invoke }
 }
-impl<'a, F: FnMut(&str, &mut dyn IConsole)> Action<'a, F> {
+
+impl<'a, F: FnMut(&str, &mut dyn IWrite)> Action<'a, F> {
+	#[inline]
 	pub fn new(name: &'a str, invoke: F) -> Action<'a, F> {
 		Action { name, invoke }
 	}
 }
-impl<'a, F: FnMut(&str, &mut dyn IConsole)> INode for Action<'a, F> {
+
+impl<'a, F: FnMut(&str, &mut dyn IWrite)> INode for Action<'a, F> {
 	fn name(&self) -> &str {
 		self.name
 	}
+
 	fn as_node(&mut self) -> Node<'_> {
 		Node::Action(self)
 	}
+
 	fn as_inode(&mut self) -> &mut dyn INode {
 		self
 	}
 }
-impl<'a, F: FnMut(&str, &mut dyn IConsole)> IAction for Action<'a, F> {
-	fn invoke(&mut self, args: &str, console: &mut dyn IConsole) {
-		(self.invoke)(args, console)
+
+impl<'a, F: FnMut(&str, &mut dyn IWrite)> IAction for Action<'a, F> {
+	fn invoke(&mut self, args: &str, writer: &mut dyn IWrite) {
+		(self.invoke)(args, writer)
 	}
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,16 +6,16 @@ struct Foo {
 	string: String,
 }
 impl Foo {
-	fn action(&mut self, arg: &str, console: &mut dyn IConsole) {
-		let _ = writeln!(console, "I am {} and {}", self.string, arg);
+	fn action(&mut self, arg: &str, writer: &mut dyn IWrite) {
+		let _ = writeln!(writer, "I am {} and {}", self.string, arg);
 	}
 }
 impl IVisit for Foo {
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn INode)) {
-		f(&mut Property::new("int", &mut self.int, 42));
-		f(&mut Property::new("float", &mut self.float, 1.2f32));
-		f(&mut Property::new("string", &mut self.string, String::new()));
-		f(&mut Action::new("action", |args, console| self.action(args, console)));
+		f(&mut Property::new("int", &mut self.int, &42));
+		f(&mut Property::new("float", &mut self.float, &1.2f32));
+		f(&mut Property::new("string", &mut self.string, &String::new()));
+		f(&mut Action::new("action", |args, writer| self.action(args, writer)));
 	}
 }
 struct Root {
@@ -25,9 +25,9 @@ struct Root {
 }
 impl IVisit for Root {
 	fn visit(&mut self, f: &mut dyn FnMut(&mut dyn INode)) {
-		f(&mut Property::new("foo.before", &mut self.before, 1));
+		f(&mut Property::new("foo.before", &mut self.before, &1));
 		f(&mut List::new("foo", &mut self.foo));
-		f(&mut Property::new("foo.after", &mut self.after, 2));
+		f(&mut Property::new("foo.after", &mut self.after, &2));
 	}
 }
 fn root() -> Root {
@@ -44,13 +44,20 @@ fn root() -> Root {
 #[test]
 fn main() {
 	let mut root = root();
-	assert!(matches!(console::set(&mut root, "foo.float", "-1"), Ok(true)));
+	let mut writer = NullWriter;
+	assert!(matches!(console::set(&mut root, "foo.float", "-1", &mut writer), true));
 	assert_eq!(root.foo.float, -1.0f32);
-	assert!(matches!(console::set(&mut root, "foo.before", "11"), Ok(true)));
-	assert!(matches!(console::set(&mut root, "foo.after", "22"), Ok(true)));
-	assert!(matches!(console::set(&mut root, "foo.int", "parse error"), Err(_)));
-	assert!(matches!(console::set(&mut root, "foo.list.bar", "name error"), Ok(false)));
-	assert!(matches!(console::set(&mut root, "foo.int.bar", "list error"), Ok(false)));
-	assert!(matches!(console::set(&mut root, "foo.action.bar", "list error"), Ok(false)));
-	assert!(matches!(console::set(&mut root, "foo.action", "prop error"), Ok(false)));
+	assert!(matches!(console::set(&mut root, "foo.before", "11", &mut writer), true));
+	assert!(matches!(console::set(&mut root, "foo.after", "22", &mut writer), true));
+	assert!(matches!(console::set(&mut root, "foo.int", "parse error", &mut writer), false));
+	assert!(matches!(console::set(&mut root, "foo.list.bar", "name error", &mut writer), false));
+	assert!(matches!(console::set(&mut root, "foo.int.bar", "list error", &mut writer), false));
+	assert!(matches!(console::set(&mut root, "foo.action.bar", "list error", &mut writer), false));
+	assert!(matches!(console::set(&mut root, "foo.action", "prop error", &mut writer), false));
+
+	assert!(console::set_value(&mut root, "foo.int", &42, &mut writer));
+	assert_eq!(console::get_value::<i32>(&mut root, "foo.int"), Some(42));
+
+	assert!(console::set(&mut root, "foo.string", "any", &mut writer));
+	assert_eq!(console::get_value::<String>(&mut root, "foo.string"), Some(String::from("any")));
 }


### PR DESCRIPTION
* Introduce IValue, interface which requires Any and Display.
* Access IProperty values through IValue. Read and write values without going through strings.
* Rename IConsole to IWrite
* Dedicated lifetime for mutable references